### PR TITLE
Add per-channel nickname lists for voice channels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,147 @@
+# IdentityCrisis Agent Guide
+# For agentic coding assistants working in this repo.
+
+## Repository overview
+- Python 3.11+ Discord bot plus FastAPI web dashboard.
+- Entry point: `main.py` runs bot + web concurrently.
+- Async SQLAlchemy models live in `shared/database.py`.
+- Web routes in `web/routes/` and templates/static assets in `web/`.
+
+## Commands (build, lint, test)
+This repo does not define linting or test scripts. Use the commands below for
+running the app and note the gaps for tests/linting.
+
+### Setup
+- Create and activate venv:
+  - `python -m venv venv`
+  - `venv\Scripts\activate` (Windows) or `source venv/bin/activate`
+- Install dependencies:
+  - `pip install -r requirements.txt`
+- Configure env:
+  - `cp .env.example .env` and fill in `DISCORD_TOKEN` and `DATABASE_URL`.
+
+### Run (dev)
+- Run bot + web together:
+  - `python main.py`
+
+### Lint
+- No linter configured in repo.
+- If adding one, keep formatting compatible with existing style (4-space indent,
+  type hints, docstrings, no enforced line length observed).
+
+### Tests
+- No automated test suite found.
+- Single-test command: N/A (no test runner configured).
+
+### Deployment notes
+- No container or deployment scripts are provided.
+- Production requires configuring `DATABASE_URL`, OAuth credentials, and a
+  `SECRET_KEY` for the web dashboard.
+
+## Code style and conventions
+Follow the patterns in the existing codebase. The guidelines below are based on
+current usage.
+
+### Formatting
+- Use 4-space indentation, no tabs.
+- Keep lines readable; there is no strict line-length policy enforced.
+- Use blank lines to separate logical blocks and import groups.
+- Docstrings are common for modules, classes, and async handlers.
+- Keep trailing whitespace out of files.
+
+### Imports
+- Group imports in this order:
+  1. Standard library
+  2. Third-party packages
+  3. Local application imports
+- Keep one blank line between each group.
+- Prefer explicit imports over `import *`.
+
+### Typing
+- Use type hints on public functions and class methods.
+- Prefer modern syntax like `list[str]`, `dict[str, int]`, and `Optional[T]`.
+- Use `Optional[T]` or `T | None` consistently within a file.
+- Pydantic models are used for API request/response schemas.
+- Route handlers usually return plain dicts with JSON-friendly values.
+
+### Naming
+- Modules and functions: `snake_case`.
+- Classes: `PascalCase`.
+- Constants: `UPPER_SNAKE_CASE`.
+- Private helpers: prefix with `_`.
+- Discord- and DB-specific IDs are generally `int` in code and stringified in
+  JSON responses.
+
+### Data and JSON
+- JSON payloads should be simple dicts/lists with serializable primitives.
+- When returning Discord IDs, cast them to strings in API responses.
+- Validate user-provided strings for length limits (nicknames cap at 32).
+
+### Async patterns
+- Prefer async SQLAlchemy sessions from the shared DB manager.
+- Use `async with db.async_session() as session:` for DB operations.
+- `await session.commit()` after mutations; `await session.refresh()` when
+  you need updated ORM objects.
+- Avoid blocking calls in async handlers.
+- Use `httpx.AsyncClient` for Discord HTTP calls.
+
+### Error handling and logging
+- Use `logger = logging.getLogger(__name__)` per module.
+- Log important lifecycle events (startup/shutdown, data sync, mutations).
+- For FastAPI routes, raise `HTTPException` with clear `status_code` and
+  `detail` strings.
+- For Discord bot operations, catch `discord.Forbidden` and
+  `discord.HTTPException`, log the error, and return a safe default.
+- When catching generic `Exception`, log with context and re-raise if the
+  failure should surface (example in `main.py` and bot setup).
+- Prefer structured log messages with placeholders instead of string concat.
+
+### FastAPI conventions
+- Routes are grouped by router in `web/routes/` with tags and prefixes.
+- Request/response bodies are defined with Pydantic models in the route module.
+- Use dependency injection via `Depends(...)` (see `get_current_user`).
+- Return JSON-friendly primitives (strings/ints/lists/dicts).
+- Use cookies for session tracking (`session_id`) and keep session logic in
+  `web/routes/auth.py` and `web/routes/dependencies.py`.
+
+### Discord bot conventions
+- Cogs live in `bot/cogs/` and are loaded in `IdentityCrisisBot.setup_hook`.
+- Avoid direct `print` except in top-level CLI/entry points.
+- Use `discord.Intents.default()` and enable only required intents.
+- Keep Discord API errors handled in the cog where possible.
+
+### Database modeling
+- SQLAlchemy models inherit from `Base` in `shared/database.py`.
+- Use `Mapped[...]` and `mapped_column` for typed columns.
+- Keep relationships explicitly defined with `back_populates`.
+- Defaults use SQL functions (`func.now`) for timestamps.
+- IDs are stored as `BigInteger` for Discord snowflakes.
+
+### Web templates and static assets
+- Templates live under `web/templates/` and are rendered by routes in
+  `web/routes/pages.py`.
+- Static assets are served from `web/static/` and mounted in `web/app.py`.
+- Keep template logic light; prefer passing computed values from routes.
+- Tailwind classes and Alpine.js are used in templates (see README).
+
+### Configuration
+- Environment configuration lives in `shared/config.py` and loads from `.env`.
+- `load_config()` should be called once at startup; use `get_config()` later.
+- Use `Config` fields rather than raw `os.getenv` in most modules.
+
+## Security and secrets
+- Never commit `.env` values or tokens.
+- Use `.env.example` as the reference for required variables.
+- Avoid logging tokens or OAuth secrets.
+
+## Repo-specific notes for agents
+- There are no Cursor or Copilot instruction files in this repo.
+- Keep changes focused; avoid reformatting unrelated code.
+- Use existing logging patterns and error messages as references.
+- Preserve the bot's playful messaging style where applicable.
+
+## Recommended workflow for changes
+1. Read relevant modules before edits (`main.py`, `bot/`, `web/`, `shared/`).
+2. Apply minimal edits with the same style and typing patterns.
+3. Run `python main.py` only if you can supply real env values.
+4. Document any missing tests or linting in PR/notes when applicable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+IdentityCrisis is a Discord bot + FastAPI web dashboard. It assigns random nicknames to users when they join voice channels. `main.py` runs both services concurrently via `asyncio.gather`.
+
+## Commands
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the application (bot + web together)
+python main.py
+```
+
+There is no test suite or linter configured in this repo.
+
+## Architecture
+
+### Startup Flow
+`main.py` → calls `load_config()` and `init_database()` from `shared/`, then spawns both the Discord bot and uvicorn web server as concurrent async tasks.
+
+### Three packages
+- **`shared/`** — `config.py` (dataclass loaded once from env, accessed via `get_config()`) and `database.py` (SQLAlchemy async models + `Database` manager, accessed via `get_db()`). Both use a module-level singleton initialized at startup.
+- **`bot/`** — `bot.py` creates the `IdentityCrisisBot` and loads cogs from `bot/cogs/`. The single cog `voice_handler.py` handles all voice state events. Default and custom nicknames come from `bot/data/`. Custom channel transformations (reverse, upside-down, leetspeak, etc.) are defined in `bot/data/transformers.py`.
+- **`web/`** — FastAPI app created by `web/app.py`. Routes split into `auth.py` (Discord OAuth2 login/callback), `pages.py` (Jinja2 page renders), `api.py` (REST endpoints for guild management), and `dependencies.py` (`get_current_user` dependency that reads/refreshes the session cookie).
+
+### Database Models (`shared/database.py`)
+- `Guild` — per-server settings (enabled, restore_on_leave, immunity_role_id)
+- `Nickname` — custom nickname pool per guild
+- `IncludedChannel` — whitelist of voice channels where the bot operates
+- `CustomChannel` — voice channels with per-channel transformation rules (stored as JSON array)
+- `MemberNickname` — per-user reset nickname (populated on voice join; `reset_nickname_manual=True` when set from dashboard)
+- `UserSession` — web dashboard OAuth sessions
+
+Tables are auto-created on startup via `Base.metadata.create_all`.
+
+### Channel Whitelist Logic
+If no `IncludedChannel` or `CustomChannel` records exist for a guild, the bot operates in all channels. Once any included or custom channel is configured, only those channels are active. Custom channels are always implicitly included.
+
+### Authentication
+Web dashboard uses Discord OAuth2. The `session_id` cookie stores the Discord user ID. `get_current_user` in `dependencies.py` looks up the `UserSession` and auto-refreshes expired tokens. The `LOG_VIEWER_ID` env var grants a single Discord user access to the `/dashboard/logs` page and the full guild list in the API.
+
+## Key Conventions
+
+- DB sessions: `async with db.async_session() as session:` — always `await session.commit()` after mutations
+- Discord IDs are `BigInteger` in the DB and cast to `str` in API JSON responses
+- `Config` is accessed via `get_config()` after `load_config()` is called in `main.py`
+- `get_db()` raises `RuntimeError` if called before `init_database()`; same pattern for `get_config()`
+- Nickname length is capped at 32 characters (Discord limit); enforced in the API and in `apply_rules()`
+- Member nickname entries older than 30 days are pruned on each `GET /api/guilds/{id}/member-nicknames` call
+
+## Environment Variables
+
+Required: `DISCORD_TOKEN`, `DATABASE_URL`
+
+Optional: `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `SECRET_KEY`, `WEB_HOST`, `WEB_PORT`, `BASE_URL`, `LOG_FILE_PATH`, `LOG_LEVEL`, `LOG_VIEWER_ID`
+
+The `DATABASE_URL` driver prefix is normalized automatically (`postgres://` → `postgresql+asyncpg://`).

--- a/bot/cogs/voice_handler.py
+++ b/bot/cogs/voice_handler.py
@@ -13,7 +13,7 @@ from discord.ext import commands
 from sqlalchemy import select
 
 from bot.data import DEFAULT_NICKNAMES, apply_rules
-from shared import IncludedChannel, Guild, MemberNickname, Nickname, get_db
+from shared import ChannelNickname, IncludedChannel, Guild, MemberNickname, Nickname, get_db
 
 logger = logging.getLogger(__name__)
 
@@ -47,16 +47,28 @@ class VoiceHandler(commands.Cog):
             if custom_nicknames:
                 return custom_nicknames
             return DEFAULT_NICKNAMES.copy()
-    
+
+    async def _get_channel_nicknames(self, guild_id: int, channel_id: int) -> list[str]:
+        """Get custom nicknames for a specific channel, if any."""
+        db = get_db()
+        async with db.async_session() as session:
+            result = await session.execute(
+                select(ChannelNickname.nickname).where(
+                    ChannelNickname.guild_id == guild_id,
+                    ChannelNickname.channel_id == channel_id
+                )
+            )
+            return [row[0] for row in result.fetchall()]
+
     async def _is_channel_allowed(self, guild_id: int, channel_id: int) -> bool:
         """
         Check if the bot is allowed to work in this channel.
-        - If no included channels AND no custom channels: ALL channels are allowed
-        - If included channels or custom channels exist: ONLY those channels are allowed
-        - Custom channels are always implicitly included
+        - If no included channels, custom channels, or channel nicknames: ALL channels are allowed
+        - If any of those exist: ONLY whitelisted channels are allowed
+        - Custom channels and channels with nickname lists are always implicitly included
         """
-        from shared import IncludedChannel, CustomChannel
-        
+        from shared import IncludedChannel, CustomChannel, ChannelNickname
+
         db = get_db()
         async with db.async_session() as session:
             # Check if this is a custom channel (always allowed)
@@ -68,28 +80,46 @@ class VoiceHandler(commands.Cog):
             )
             if result.scalar_one_or_none():
                 return True
-            
+
+            # Check if this channel has a custom nickname list (always allowed)
+            result = await session.execute(
+                select(ChannelNickname.id).where(
+                    ChannelNickname.guild_id == guild_id,
+                    ChannelNickname.channel_id == channel_id
+                ).limit(1)
+            )
+            if result.scalar_one_or_none():
+                return True
+
             # Get included channels
             result = await session.execute(
                 select(IncludedChannel).where(IncludedChannel.guild_id == guild_id)
             )
             included_channels = result.scalars().all()
-            
+
             # Get custom channels (to check if any exist)
             result = await session.execute(
                 select(CustomChannel).where(CustomChannel.guild_id == guild_id)
             )
             custom_channels = result.scalars().all()
-            
-            # If no included channels AND no custom channels, all channels are allowed
-            if not included_channels and not custom_channels:
+
+            # Check if any channel nicknames exist for this guild
+            result = await session.execute(
+                select(ChannelNickname.id).where(
+                    ChannelNickname.guild_id == guild_id
+                ).limit(1)
+            )
+            has_channel_nicknames = result.scalar_one_or_none() is not None
+
+            # If no included channels AND no custom channels AND no channel nicknames, all allowed
+            if not included_channels and not custom_channels and not has_channel_nicknames:
                 return True
-            
+
             # If we have included channels, check if this channel is in the list
             if included_channels:
                 return any(ch.channel_id == channel_id for ch in included_channels)
-            
-            # If we only have custom channels (but this isn't one of them), not allowed
+
+            # If we only have custom channels/channel nicknames (but this isn't one), not allowed
             return False
         
     async def _get_custom_channel_rules(self, guild_id: int, channel_id: int) -> list[dict] | None:
@@ -465,14 +495,33 @@ class VoiceHandler(commands.Cog):
                     member.display_name
                 )
             
-            # Check for custom channel rules first
-            custom_rules = await self._get_custom_channel_rules(
-                member.guild.id, 
+            # Get channel-specific nicknames and custom rules
+            channel_nicknames = await self._get_channel_nicknames(
+                member.guild.id,
                 after.channel.id
             )
-            
-            if custom_rules:
-                # Apply transformation rules to the user's ORIGINAL display name
+            custom_rules = await self._get_custom_channel_rules(
+                member.guild.id,
+                after.channel.id
+            )
+
+            if channel_nicknames:
+                # Channel has its own nickname list
+                base = random.choice(channel_nicknames)
+                if custom_rules:
+                    new_nickname = apply_rules(base, custom_rules)
+                    logger.debug(
+                        "Channel nickname + rules for %s in guild %s: base=%r, result=%r",
+                        member.id, member.guild.id, base, new_nickname,
+                    )
+                else:
+                    new_nickname = base
+                    logger.debug(
+                        "Channel nickname for %s in guild %s: %r",
+                        member.id, member.guild.id, new_nickname,
+                    )
+            elif custom_rules:
+                # Existing behavior: transform original display name
                 original_name = self._get_original_display_name(member.guild.id, member.id)
                 if not original_name:
                     logger.debug(
@@ -497,10 +546,10 @@ class VoiceHandler(commands.Cog):
                     new_nickname,
                 )
             else:
-                # Standard random nickname
+                # Standard random nickname from guild pool
                 nicknames = await self._get_guild_nicknames(member.guild.id)
                 new_nickname = random.choice(nicknames)
-            
+
             await self._change_nickname(member, new_nickname)
 
 

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -4,6 +4,7 @@ from .config import Config, get_config, load_config
 from .database import (
     Base,
     Database,
+    ChannelNickname,
     IncludedChannel,
     CustomChannel,
     Guild,
@@ -22,6 +23,7 @@ __all__ = [
     "Database",
     "Guild",
     "Nickname",
+    "ChannelNickname",
     "IncludedChannel",
     "CustomChannel",
     "MemberNickname",

--- a/shared/database.py
+++ b/shared/database.py
@@ -57,6 +57,10 @@ class Guild(Base):
         back_populates="guild",
         cascade="all, delete-orphan"
     )
+    channel_nicknames: Mapped[list["ChannelNickname"]] = relationship(
+        back_populates="guild",
+        cascade="all, delete-orphan"
+    )
 
 
 class Nickname(Base):
@@ -97,6 +101,24 @@ class CustomChannel(Base):
     
     # Relationship
     guild: Mapped["Guild"] = relationship(back_populates="custom_channels")
+
+
+class ChannelNickname(Base):
+    """Custom nicknames for a specific voice channel in a guild."""
+    __tablename__ = "channel_nicknames"
+    __table_args__ = (
+        UniqueConstraint("guild_id", "channel_id", "nickname",
+                         name="uq_channel_nicknames_guild_channel_nick"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    guild_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("guilds.id", ondelete="CASCADE"))
+    channel_id: Mapped[int] = mapped_column(BigInteger)
+    channel_name: Mapped[str] = mapped_column(String(100))
+    nickname: Mapped[str] = mapped_column(String(32))  # Discord nickname limit
+
+    # Relationship
+    guild: Mapped["Guild"] = relationship(back_populates="channel_nicknames")
 
 
 class MemberNickname(Base):

--- a/web/routes/api.py
+++ b/web/routes/api.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select
 
-from shared import CustomChannel, Guild, IncludedChannel, MemberNickname, Nickname, UserSession, get_config, get_db
+from shared import ChannelNickname, CustomChannel, Guild, IncludedChannel, MemberNickname, Nickname, UserSession, get_config, get_db
 from web.discord_oauth import DiscordOAuth
 from web.routes.dependencies import get_current_user
 
@@ -108,6 +108,12 @@ class MessageResponse(BaseModel):
 class MemberNicknameUpdate(BaseModel):
     reset_nickname: Optional[str] = None
     manual: bool = True
+
+
+class ChannelNicknameCreate(BaseModel):
+    channel_id: str
+    channel_name: str
+    nickname: str
 
 
 class LogLevelUpdate(BaseModel):
@@ -752,10 +758,137 @@ async def delete_custom_channel(
 async def get_available_rules():
     """Get list of available transformation rules."""
     from bot.data import TRANSFORMER_NAMES
-    
+
     return {
         "rules": [
             {"type": key, "name": name, "has_value": key in ["prefix", "suffix"]}
             for key, name in TRANSFORMER_NAMES.items()
         ]
     }
+
+
+# Channel Nickname Lists
+@router.get("/guilds/{guild_id}/channel-nicknames")
+async def get_channel_nicknames(
+    guild_id: int,
+    user: UserSession = Depends(get_current_user)
+):
+    """Get all channel-specific nicknames for a guild, grouped by channel."""
+    db = get_db()
+    async with db.async_session() as session:
+        result = await session.execute(
+            select(ChannelNickname).where(ChannelNickname.guild_id == guild_id)
+        )
+        entries = result.scalars().all()
+
+        channels: dict[str, dict] = {}
+        for entry in entries:
+            ch_id = str(entry.channel_id)
+            if ch_id not in channels:
+                channels[ch_id] = {
+                    "channel_id": ch_id,
+                    "channel_name": entry.channel_name,
+                    "nicknames": [],
+                }
+            channels[ch_id]["nicknames"].append({
+                "id": entry.id,
+                "nickname": entry.nickname,
+            })
+
+        return {"channels": list(channels.values())}
+
+
+@router.post("/guilds/{guild_id}/channel-nicknames")
+async def add_channel_nickname(
+    guild_id: int,
+    data: ChannelNicknameCreate,
+    user: UserSession = Depends(get_current_user)
+):
+    """Add a nickname to a specific channel."""
+    if len(data.nickname) > 32:
+        raise HTTPException(
+            status_code=400,
+            detail="Nickname must be 32 characters or less"
+        )
+
+    db = get_db()
+    async with db.async_session() as session:
+        result = await session.execute(
+            select(Guild).where(Guild.id == guild_id)
+        )
+        if not result.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Guild not found")
+
+        # Check for duplicate
+        result = await session.execute(
+            select(ChannelNickname).where(
+                ChannelNickname.guild_id == guild_id,
+                ChannelNickname.channel_id == int(data.channel_id),
+                ChannelNickname.nickname == data.nickname
+            )
+        )
+        if result.scalar_one_or_none():
+            raise HTTPException(status_code=400, detail="Nickname already exists for this channel")
+
+        entry = ChannelNickname(
+            guild_id=guild_id,
+            channel_id=int(data.channel_id),
+            channel_name=data.channel_name,
+            nickname=data.nickname,
+        )
+        session.add(entry)
+        await session.commit()
+        await session.refresh(entry)
+
+        return {
+            "id": entry.id,
+            "channel_id": str(entry.channel_id),
+            "channel_name": entry.channel_name,
+            "nickname": entry.nickname,
+        }
+
+
+@router.delete("/guilds/{guild_id}/channel-nicknames/{nickname_id}")
+async def delete_channel_nickname(
+    guild_id: int,
+    nickname_id: int,
+    user: UserSession = Depends(get_current_user)
+):
+    """Delete a single nickname from a channel."""
+    db = get_db()
+    async with db.async_session() as session:
+        result = await session.execute(
+            delete(ChannelNickname).where(
+                ChannelNickname.id == nickname_id,
+                ChannelNickname.guild_id == guild_id
+            )
+        )
+        await session.commit()
+
+        if result.rowcount == 0:
+            raise HTTPException(status_code=404, detail="Channel nickname not found")
+
+        return {"message": "Channel nickname deleted"}
+
+
+@router.delete("/guilds/{guild_id}/channel-nicknames/channel/{channel_id}")
+async def delete_channel_nickname_list(
+    guild_id: int,
+    channel_id: int,
+    user: UserSession = Depends(get_current_user)
+):
+    """Delete all nicknames for a specific channel."""
+    db = get_db()
+    async with db.async_session() as session:
+        result = await session.execute(
+            delete(ChannelNickname).where(
+                ChannelNickname.guild_id == guild_id,
+                ChannelNickname.channel_id == channel_id
+            )
+        )
+        await session.commit()
+
+        if result.rowcount == 0:
+            raise HTTPException(status_code=404, detail="No nicknames found for this channel")
+
+        return {"message": f"All nicknames for channel removed ({result.rowcount} deleted)"}

--- a/web/templates/guild.html
+++ b/web/templates/guild.html
@@ -194,6 +194,90 @@
             </div>
         </div>
         
+        <!-- Channel Nickname Lists Card -->
+        <div class="bg-discord-dark rounded-xl border border-gray-700 mb-8">
+            <div class="p-6 border-b border-gray-700 flex items-center justify-between">
+                <div>
+                    <h2 class="text-lg font-semibold text-white">Channel Nickname Lists</h2>
+                    <p class="text-sm text-gray-400">Assign different nickname pools to specific voice channels.</p>
+                </div>
+                <span class="text-sm text-gray-500" x-text="channelNicknameGroups.length + ' channel(s)'"></span>
+            </div>
+            <div class="p-6">
+                <!-- Add form -->
+                <div class="mb-6 p-4 bg-discord-darker rounded-lg">
+                    <div class="flex gap-3 mb-3">
+                        <input type="text"
+                               x-model="newChNickChannelId"
+                               placeholder="Channel ID"
+                               class="w-48 bg-discord-dark border border-gray-600 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-discord-blurple">
+                        <input type="text"
+                               x-model="newChNickChannelName"
+                               placeholder="Channel Name"
+                               class="flex-1 bg-discord-dark border border-gray-600 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-discord-blurple">
+                    </div>
+                    <form @submit.prevent="addChannelNickname()" class="flex gap-3">
+                        <input type="text"
+                               x-model="newChNickInput"
+                               maxlength="32"
+                               placeholder="Enter a nickname for this channel..."
+                               class="flex-1 bg-discord-dark border border-gray-600 rounded-lg px-4 py-2 text-white placeholder-gray-500 focus:outline-none focus:border-discord-blurple">
+                        <button type="submit"
+                                :disabled="!newChNickChannelId.trim() || !newChNickChannelName.trim() || !newChNickInput.trim()"
+                                class="px-4 py-2 bg-discord-blurple hover:bg-opacity-80 disabled:bg-gray-600 disabled:cursor-not-allowed rounded-lg text-white font-medium transition-colors">
+                            Add
+                        </button>
+                    </form>
+                </div>
+
+                <!-- Info box -->
+                <div class="mb-4 p-3 bg-discord-blurple/10 border border-discord-blurple/30 rounded-lg">
+                    <p class="text-sm text-gray-300">
+                        <span class="text-discord-blurple font-medium">Tip:</span>
+                        Channels with nickname lists are automatically included in the whitelist.
+                        If a channel also has custom rules, the rules will be applied to the randomly picked channel nickname.
+                    </p>
+                </div>
+
+                <!-- Channel groups -->
+                <div x-show="channelNicknameGroups.length > 0" class="space-y-3">
+                    <template x-for="group in channelNicknameGroups" :key="group.channel_id">
+                        <div class="bg-discord-darker rounded-lg p-4">
+                            <div class="flex items-center justify-between mb-3">
+                                <div>
+                                    <span class="text-white font-medium" x-text="group.channel_name"></span>
+                                    <span class="text-xs text-gray-500 ml-2" x-text="'#' + group.channel_id"></span>
+                                    <span class="text-xs text-gray-500 ml-2" x-text="group.nicknames.length + ' nickname(s)'"></span>
+                                </div>
+                                <button @click="deleteChannelNicknameList(group.channel_id)"
+                                        class="text-gray-500 hover:text-discord-red transition-colors text-xs">
+                                    Remove All
+                                </button>
+                            </div>
+                            <div class="space-y-1">
+                                <template x-for="nick in group.nicknames" :key="nick.id">
+                                    <div class="flex items-center justify-between bg-discord-dark rounded px-3 py-2 group">
+                                        <span class="text-gray-300 text-sm" x-text="nick.nickname"></span>
+                                        <button @click="deleteChannelNickname(nick.id)"
+                                                class="text-gray-500 hover:text-discord-red opacity-0 group-hover:opacity-100 transition-all">
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+
+                <!-- Empty state -->
+                <div x-show="channelNicknameGroups.length === 0" class="text-center py-8 text-gray-500">
+                    <p>No channel-specific nicknames. Channels will use the guild-wide list.</p>
+                </div>
+            </div>
+        </div>
+
         <!-- Included Channels Card -->
         <div class="bg-discord-dark rounded-xl border border-gray-700">
             <div class="p-6 border-b border-gray-700 flex items-center justify-between">
@@ -381,7 +465,11 @@ function guildSettings(guildId) {
         newCustomChannelId: '',
         newCustomChannelName: '',
         newCustomRules: [],
-        
+        channelNicknameGroups: [],
+        newChNickChannelId: '',
+        newChNickChannelName: '',
+        newChNickInput: '',
+
         async init() {
             await Promise.all([
                 this.loadGuild(),
@@ -389,6 +477,7 @@ function guildSettings(guildId) {
                 this.loadMemberNicknames(),
                 this.loadIncludedChannels(),
                 this.loadCustomChannels(),
+                this.loadChannelNicknames(),
                 this.loadAvailableRules()
             ]);
             this.loading = false;
@@ -639,7 +728,64 @@ function guildSettings(guildId) {
                 this.customChannels = data.channels;
             }
         },
-        
+
+        async loadChannelNicknames() {
+            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames`);
+            if (response.ok) {
+                const data = await response.json();
+                this.channelNicknameGroups = data.channels;
+            }
+        },
+
+        async addChannelNickname() {
+            if (!this.newChNickChannelId.trim() || !this.newChNickChannelName.trim() || !this.newChNickInput.trim()) return;
+
+            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    channel_id: this.newChNickChannelId.trim(),
+                    channel_name: this.newChNickChannelName.trim(),
+                    nickname: this.newChNickInput.trim()
+                })
+            });
+
+            if (response.ok) {
+                this.newChNickInput = '';
+                await this.loadChannelNicknames();
+                this.toast('Channel nickname added!', 'success');
+            } else {
+                const error = await response.json();
+                this.toast(error.detail || 'Failed to add channel nickname', 'error');
+            }
+        },
+
+        async deleteChannelNickname(nicknameId) {
+            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames/${nicknameId}`, {
+                method: 'DELETE'
+            });
+
+            if (response.ok) {
+                await this.loadChannelNicknames();
+                this.toast('Channel nickname deleted!', 'success');
+            } else {
+                this.toast('Failed to delete channel nickname', 'error');
+            }
+        },
+
+        async deleteChannelNicknameList(channelId) {
+            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames/channel/${channelId}`, {
+                method: 'DELETE'
+            });
+
+            if (response.ok) {
+                await this.loadChannelNicknames();
+                this.toast('All nicknames for channel removed!', 'success');
+            } else {
+                this.toast('Failed to remove channel nicknames', 'error');
+            }
+        },
+
         async loadAvailableRules() {
             const response = await fetch('/api/available-rules');
             if (response.ok) {


### PR DESCRIPTION
## Summary
- New `ChannelNickname` database model to store per-voice-channel nickname pools
- CRUD API endpoints (`/api/guilds/{id}/channel-nicknames`) for managing channel-specific nickname lists
- Updated bot nickname selection: channel list > custom rules (original name) > guild list > defaults
- If a channel has both a nickname list and transformation rules, the bot picks from the list then applies the rules
- Channels with nickname lists are implicitly included in the whitelist
- New "Channel Nickname Lists" card in the guild settings dashboard UI
