### PR TITLE
Add ROOT_PATH support and SQLite backend for sub-path deployments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ jinja2>=3.1.0
 # Database
 sqlalchemy[asyncio]>=2.0.0
 asyncpg>=0.29.0
+aiosqlite>=0.19.0
 
 # HTTP client (for Discord OAuth)
 httpx>=0.26.0

--- a/shared/config.py
+++ b/shared/config.py
@@ -29,6 +29,7 @@ class Config:
     web_host: str = "0.0.0.0"
     web_port: int = 8000
     base_url: str = "http://localhost:8000"
+    root_path: str = ""
     log_file_path: str = "logs/identitycrisis.log"
     log_viewer_id: Optional[int] = None
     
@@ -68,6 +69,7 @@ class Config:
             web_host=os.getenv("WEB_HOST", "0.0.0.0"),
             web_port=int(os.getenv("WEB_PORT", "8000")),
             base_url=os.getenv("BASE_URL", "http://localhost:8000"),
+            root_path=os.getenv("ROOT_PATH", "").rstrip("/"),
             log_file_path=os.getenv("LOG_FILE_PATH", "logs/identitycrisis.log"),
             log_viewer_id=int(os.getenv("LOG_VIEWER_ID")) if os.getenv("LOG_VIEWER_ID") else None,
         )

--- a/shared/database.py
+++ b/shared/database.py
@@ -1,12 +1,12 @@
 """
 Shared database module for IdentityCrisis.
-Uses SQLAlchemy async with PostgreSQL.
+Uses SQLAlchemy async with PostgreSQL or SQLite.
 """
 
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, String, Text, JSON, func, UniqueConstraint
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, String, Text, JSON, func, UniqueConstraint, event
 from sqlalchemy.ext.asyncio import AsyncAttrs, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -181,15 +181,25 @@ class Database:
     """Database connection manager."""
     
     def __init__(self, database_url: str):
-        # Convert postgres:// to postgresql+asyncpg://
-        if database_url.startswith("postgres://"):
-            database_url = database_url.replace("postgres://", "postgresql+asyncpg://", 1)
-        elif database_url.startswith("postgresql://"):
-            database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
-        
-        self.engine = create_async_engine(database_url, echo=False)
+        if database_url.startswith("sqlite"):
+            if "aiosqlite" not in database_url:
+                database_url = database_url.replace("sqlite://", "sqlite+aiosqlite://", 1)
+            self.engine = create_async_engine(database_url, echo=False)
+            # Enable foreign keys for SQLite
+            @event.listens_for(self.engine.sync_engine, "connect")
+            def set_sqlite_pragma(dbapi_conn, connection_record):
+                cursor = dbapi_conn.cursor()
+                cursor.execute("PRAGMA foreign_keys=ON")
+                cursor.close()
+        else:
+            if database_url.startswith("postgres://"):
+                database_url = database_url.replace("postgres://", "postgresql+asyncpg://", 1)
+            elif database_url.startswith("postgresql://"):
+                database_url = database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+            self.engine = create_async_engine(database_url, echo=False)
+
         self.async_session = async_sessionmaker(
-            self.engine, 
+            self.engine,
             expire_on_commit=False
         )
     

--- a/web/app.py
+++ b/web/app.py
@@ -7,6 +7,7 @@ import logging
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
+from shared import get_config
 from web.routes import api_router, auth_router, pages_router
 
 logger = logging.getLogger(__name__)
@@ -14,26 +15,29 @@ logger = logging.getLogger(__name__)
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
+    config = get_config()
+
     app = FastAPI(
         title="IdentityCrisis Dashboard",
         description="Web dashboard for managing the IdentityCrisis Discord bot",
         version="1.0.0",
+        root_path=config.root_path,
     )
-    
+
     # Mount static files
     app.mount("/static", StaticFiles(directory="web/static"), name="static")
-    
+
     # Include routers
     app.include_router(auth_router)
     app.include_router(api_router)
     app.include_router(pages_router)
-    
+
     @app.on_event("startup")
     async def startup():
         logger.info("Web dashboard starting up...")
-    
+
     @app.on_event("shutdown")
     async def shutdown():
         logger.info("Web dashboard shutting down...")
-    
+
     return app

--- a/web/routes/auth.py
+++ b/web/routes/auth.py
@@ -12,6 +12,10 @@ from sqlalchemy import select
 from shared import UserSession, get_config, get_db
 from web.discord_oauth import DiscordOAuth
 
+
+def _rp() -> str:
+    return get_config().root_path
+
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -75,13 +79,15 @@ async def callback(request: Request, code: str = None, error: str = None):
             await session.commit()
         
         # Set session cookie and redirect to dashboard
-        response = RedirectResponse(url="/dashboard", status_code=302)
+        rp = _rp()
+        response = RedirectResponse(url=f"{rp}/dashboard", status_code=302)
         response.set_cookie(
             key="session_id",
             value=str(user["id"]),
             httponly=True,
             max_age=60 * 60 * 24 * 7,  # 7 days
             samesite="lax",
+            path=f"{rp}/" if rp else "/",
         )
         return response
         
@@ -93,6 +99,7 @@ async def callback(request: Request, code: str = None, error: str = None):
 @router.get("/logout")
 async def logout(request: Request):
     """Log out the user."""
-    response = RedirectResponse(url="/", status_code=302)
-    response.delete_cookie("session_id")
+    rp = _rp()
+    response = RedirectResponse(url=f"{rp}/", status_code=302)
+    response.delete_cookie("session_id", path=f"{rp}/" if rp else "/")
     return response

--- a/web/routes/pages.py
+++ b/web/routes/pages.py
@@ -12,6 +12,10 @@ from web.routes.dependencies import get_optional_user
 router = APIRouter(tags=["pages"])
 templates = Jinja2Templates(directory="web/templates")
 
+
+def _login_url() -> str:
+    return f"{get_config().root_path}/auth/login"
+
 def _is_log_viewer(user: UserSession | None, config) -> bool:
     return bool(user and config.log_viewer_id and user.discord_id == config.log_viewer_id)
 
@@ -41,7 +45,7 @@ async def dashboard(
 ):
     """Dashboard page - shows user's servers."""
     if not user:
-        return RedirectResponse(url="/auth/login", status_code=302)
+        return RedirectResponse(url=_login_url(), status_code=302)
     
     config = get_config()
     return templates.TemplateResponse(
@@ -63,7 +67,7 @@ async def guild_settings(
 ):
     """Guild settings page."""
     if not user:
-        return RedirectResponse(url="/auth/login", status_code=302)
+        return RedirectResponse(url=_login_url(), status_code=302)
     
     config = get_config()
     return templates.TemplateResponse(
@@ -85,7 +89,7 @@ async def logs(
 ):
     """Bot logs page (restricted)."""
     if not user:
-        return RedirectResponse(url="/auth/login", status_code=302)
+        return RedirectResponse(url=_login_url(), status_code=302)
 
     config = get_config()
     if not _is_log_viewer(user, config):

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -30,6 +30,7 @@
     
     <!-- Alpine.js for interactivity -->
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <script>var ROOT_PATH = '{{ config.root_path if config else "" }}';</script>
     
     <style>
         [x-cloak] { display: none !important; }
@@ -44,7 +45,7 @@
             <div class="flex items-center justify-between h-16">
                 <!-- Logo -->
                 <div class="flex items-center">
-                    <a href="/" class="flex items-center space-x-3">
+                    <a href="{{ config.root_path }}/" class="flex items-center space-x-3">
                         <span class="text-2xl">🎭</span>
                         <span class="text-xl font-bold text-white">IdentityCrisis</span>
                     </a>
@@ -53,11 +54,11 @@
                 <!-- Navigation links -->
                 <div class="flex items-center space-x-4">
                     {% if user %}
-                        <a href="/dashboard" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">
+                        <a href="{{ config.root_path }}/dashboard" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">
                             Dashboard
                         </a>
                         {% if is_log_viewer %}
-                            <a href="/dashboard/logs" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">
+                            <a href="{{ config.root_path }}/dashboard/logs" class="text-gray-300 hover:text-white px-3 py-2 rounded-md text-sm font-medium">
                                 Logs
                             </a>
                         {% endif %}
@@ -70,12 +71,12 @@
                                 </div>
                             {% endif %}
                             <span class="text-sm text-gray-300">{{ user.username }}</span>
-                            <a href="/auth/logout" class="text-gray-400 hover:text-white text-sm">
+                            <a href="{{ config.root_path }}/auth/logout" class="text-gray-400 hover:text-white text-sm">
                                 Logout
                             </a>
                         </div>
                     {% else %}
-                        <a href="/auth/login" class="bg-discord-blurple hover:bg-opacity-80 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors">
+                        <a href="{{ config.root_path }}/auth/login" class="bg-discord-blurple hover:bg-opacity-80 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors">
                             Login with Discord
                         </a>
                     {% endif %}

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -40,7 +40,7 @@
     <div x-show="!loading && guilds.length > 0" x-cloak
          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         <template x-for="guild in guilds" :key="guild.id">
-            <a :href="'/dashboard/guild/' + guild.id"
+            <a :href="ROOT_PATH + '/dashboard/guild/' + guild.id"
                class="bg-discord-dark rounded-xl p-6 border border-gray-700 hover:border-discord-blurple transition-all hover:transform hover:scale-[1.02] group">
                 <div class="flex items-center space-x-4">
                     <template x-if="guild.icon_url">
@@ -78,10 +78,10 @@ function dashboard() {
         
         async init() {
             try {
-                const response = await fetch('/api/guilds');
+                const response = await fetch(ROOT_PATH + '/api/guilds');
                 if (!response.ok) {
                     if (response.status === 401) {
-                        window.location.href = '/auth/login';
+                        window.location.href = ROOT_PATH + '/auth/login';
                         return;
                     }
                     throw new Error('Failed to load servers');

--- a/web/templates/guild.html
+++ b/web/templates/guild.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12" x-data="guildSettings('{{ guild_id }}')">
     <!-- Back button -->
-    <a href="/dashboard" class="inline-flex items-center text-gray-400 hover:text-white mb-6 transition-colors">
+    <a href="{{ config.root_path }}/dashboard" class="inline-flex items-center text-gray-400 hover:text-white mb-6 transition-colors">
         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
         </svg>
@@ -490,14 +490,14 @@ function guildSettings(guildId) {
         },
         
         async loadGuild() {
-            const response = await fetch(`/api/guilds/${this.guildId}`);
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}`);
             if (response.ok) {
                 this.guild = await response.json();
             }
         },
         
         async loadNicknames() {
-            const response = await fetch(`/api/guilds/${this.guildId}/nicknames`);
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/nicknames`);
             if (response.ok) {
                 const data = await response.json();
                 this.nicknames = data.nicknames;
@@ -506,7 +506,7 @@ function guildSettings(guildId) {
 
         async loadMemberNicknames(page = this.memberPage) {
             this.memberLoading = true;
-            const response = await fetch(`/api/guilds/${this.guildId}/member-nicknames?page=${page}&page_size=${this.memberPageSize}`);
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/member-nicknames?page=${page}&page_size=${this.memberPageSize}`);
             if (response.ok) {
                 const data = await response.json();
                 this.memberNicknames = data.members.map(member => ({
@@ -549,7 +549,7 @@ function guildSettings(guildId) {
         },
         
         async loadIncludedChannels() {
-            const response = await fetch(`/api/guilds/${this.guildId}/included-channels`);
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/included-channels`);
             if (response.ok) {
                 const data = await response.json();
                 this.includedChannels = data.channels;
@@ -557,7 +557,7 @@ function guildSettings(guildId) {
         },
         
         async updateSettings() {
-            const response = await fetch(`/api/guilds/${this.guildId}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -587,7 +587,7 @@ function guildSettings(guildId) {
         async addNickname() {
             if (!this.newNickname.trim()) return;
             
-            const response = await fetch(`/api/guilds/${this.guildId}/nicknames`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/nicknames`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ nickname: this.newNickname.trim() })
@@ -604,7 +604,7 @@ function guildSettings(guildId) {
         },
         
         async deleteNickname(id) {
-            const response = await fetch(`/api/guilds/${this.guildId}/nicknames/${id}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/nicknames/${id}`, {
                 method: 'DELETE'
             });
             
@@ -617,7 +617,7 @@ function guildSettings(guildId) {
         },
 
         async saveMemberNickname(member) {
-            const response = await fetch(`/api/guilds/${this.guildId}/member-nicknames/${member.user_id}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/member-nicknames/${member.user_id}`, {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -644,7 +644,7 @@ function guildSettings(guildId) {
         },
 
         async removeMemberNickname(member) {
-            const response = await fetch(`/api/guilds/${this.guildId}/member-nicknames/${member.user_id}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/member-nicknames/${member.user_id}`, {
                 method: 'DELETE'
             });
 
@@ -687,7 +687,7 @@ function guildSettings(guildId) {
         async addIncludedChannel() {
             if (!this.newChannelId.trim() || !this.newChannelName.trim()) return;
             
-            const response = await fetch(`/api/guilds/${this.guildId}/included-channels`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/included-channels`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ 
@@ -709,7 +709,7 @@ function guildSettings(guildId) {
         },
         
         async removeIncludedChannel(id) {
-            const response = await fetch(`/api/guilds/${this.guildId}/included-channels/${id}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/included-channels/${id}`, {
                 method: 'DELETE'
             });
             
@@ -722,7 +722,7 @@ function guildSettings(guildId) {
         },
 
 		async loadCustomChannels() {
-            const response = await fetch(`/api/guilds/${this.guildId}/custom-channels`);
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/custom-channels`);
             if (response.ok) {
                 const data = await response.json();
                 this.customChannels = data.channels;
@@ -730,7 +730,7 @@ function guildSettings(guildId) {
         },
 
         async loadChannelNicknames() {
-            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames`);
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/channel-nicknames`);
             if (response.ok) {
                 const data = await response.json();
                 this.channelNicknameGroups = data.channels;
@@ -740,7 +740,7 @@ function guildSettings(guildId) {
         async addChannelNickname() {
             if (!this.newChNickChannelId.trim() || !this.newChNickChannelName.trim() || !this.newChNickInput.trim()) return;
 
-            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/channel-nicknames`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -761,7 +761,7 @@ function guildSettings(guildId) {
         },
 
         async deleteChannelNickname(nicknameId) {
-            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames/${nicknameId}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/channel-nicknames/${nicknameId}`, {
                 method: 'DELETE'
             });
 
@@ -774,7 +774,7 @@ function guildSettings(guildId) {
         },
 
         async deleteChannelNicknameList(channelId) {
-            const response = await fetch(`/api/guilds/${this.guildId}/channel-nicknames/channel/${channelId}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/channel-nicknames/channel/${channelId}`, {
                 method: 'DELETE'
             });
 
@@ -787,7 +787,7 @@ function guildSettings(guildId) {
         },
 
         async loadAvailableRules() {
-            const response = await fetch('/api/available-rules');
+            const response = await fetch(ROOT_PATH + '/api/available-rules');
             if (response.ok) {
                 const data = await response.json();
                 this.availableRules = data.rules;
@@ -848,7 +848,7 @@ function guildSettings(guildId) {
         async addCustomChannel() {
             if (!this.newCustomChannelId.trim() || !this.newCustomChannelName.trim() || this.newCustomRules.length === 0) return;
             
-            const response = await fetch(`/api/guilds/${this.guildId}/custom-channels`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/custom-channels`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
@@ -872,7 +872,7 @@ function guildSettings(guildId) {
         },
         
         async deleteCustomChannel(id) {
-            const response = await fetch(`/api/guilds/${this.guildId}/custom-channels/${id}`, {
+            const response = await fetch(`${ROOT_PATH}/api/guilds/${this.guildId}/custom-channels/${id}`, {
                 method: 'DELETE'
             });
             

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -18,11 +18,11 @@
             
             <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
                 {% if user %}
-                    <a href="/dashboard" class="w-full sm:w-auto bg-discord-blurple hover:bg-opacity-80 text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all transform hover:scale-105 shadow-lg">
+                    <a href="{{ config.root_path }}/dashboard" class="w-full sm:w-auto bg-discord-blurple hover:bg-opacity-80 text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all transform hover:scale-105 shadow-lg">
                         Go to Dashboard
                     </a>
                 {% else %}
-                    <a href="/auth/login" class="w-full sm:w-auto bg-discord-blurple hover:bg-opacity-80 text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all transform hover:scale-105 shadow-lg flex items-center justify-center space-x-2">
+                    <a href="{{ config.root_path }}/auth/login" class="w-full sm:w-auto bg-discord-blurple hover:bg-opacity-80 text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all transform hover:scale-105 shadow-lg flex items-center justify-center space-x-2">
                         <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
                         </svg>

--- a/web/templates/logs.html
+++ b/web/templates/logs.html
@@ -63,7 +63,7 @@ function logViewer() {
         async refreshLogLevel() {
             if (this.logLevelLoading) return;
             this.logLevelLoading = true;
-            const response = await fetch('/api/logs/level');
+            const response = await fetch(ROOT_PATH + '/api/logs/level');
             if (response.ok) {
                 const data = await response.json();
                 this.logLevel = data.level || 'INFO';
@@ -75,7 +75,7 @@ function logViewer() {
             if (this.logLevelLoading) return;
             this.logLevelLoading = true;
             const nextLevel = this.logLevel === 'DEBUG' ? 'INFO' : 'DEBUG';
-            const response = await fetch('/api/logs/level', {
+            const response = await fetch(ROOT_PATH + '/api/logs/level', {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ level: nextLevel })
@@ -93,7 +93,7 @@ function logViewer() {
         async refreshLogs() {
             if (this.loading) return;
             this.loading = true;
-            const response = await fetch(`/api/logs?lines=${this.linesLimit}`);
+            const response = await fetch(`${ROOT_PATH}/api/logs?lines=${this.linesLimit}`);
             if (response.ok) {
                 const data = await response.json();
                 this.logs = data.lines || [];
@@ -109,7 +109,7 @@ function logViewer() {
             if (this.loading) return;
             if (!confirm('Clear all logs?')) return;
             this.loading = true;
-            const response = await fetch('/api/logs', { method: 'DELETE' });
+            const response = await fetch(ROOT_PATH + '/api/logs', { method: 'DELETE' });
             if (response.ok) {
                 this.logs = [];
                 this.lastUpdated = new Date().toLocaleTimeString();


### PR DESCRIPTION
- Add ROOT_PATH env var to config for serving behind a reverse proxy at a sub-path (e.g. /identitycrisis)
- Prefix all template hrefs and JS fetch calls with the configurable root path so links resolve correctly behind nginx
- Set cookie path to root_path scope for proper session handling
- Add SQLite/aiosqlite support as alternative to PostgreSQL, with automatic foreign key pragma enforcement
- Pass root_path to FastAPI constructor for correct OpenAPI/docs URLs